### PR TITLE
Update Vagrantfile to vagrant 1.2, fix some script quirks

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,16 +1,16 @@
 # -*- mode: ruby -*-
-# vi: set ft=ruby :
+# vi: set ft=ruby sw=2 :
 
-Vagrant::Config.run do |config|
+Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu-12.04-32bit"
   config.vm.box_url = "http://files.vagrantup.com/precise32.box"
 
-  config.vm.share_folder("cross-compiler", "~/cross-compiler", ".")
+  config.vm.synced_folder ".", "/home/vagrant/cross-compiler"
 
-  # Allow symlinks
-  config.vm.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/cross-compiler", "1"]
-  # Otherwise the compile will go into swap, making things slow
-  config.vm.customize ["modifyvm", :id, "--memory", "2048"]
-  # Setup virtual machine
-  #config.vm.provision :shell, :inline => "./cross-compiler/setup-vm.sh"
+  config.vm.provider "virtualbox" do |v|
+    # Otherwise the compile will go into swap, making things slow
+    v.customize ["modifyvm", :id, "--memory", "2048"]
+    # Allow symlinks
+    v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/cross-compiler", "1"]
+  end
 end

--- a/helpers/ardrone2.sh
+++ b/helpers/ardrone2.sh
@@ -6,6 +6,9 @@ if [ ! -e build/bin/node ]; then
   vagrant up
   echo "-> Building node binary"
   vagrant ssh -c "cd cross-compiler && ./setup-vm.sh && make ardrone2"
+  echo "-> Halting VM"
+  vagrant halt
+  echo "-> To completely remove the VM, please execute 'vagrant destroy'"
 else
   echo "-> Skipping build (node binary exists)"
 fi

--- a/setup-vm.sh
+++ b/setup-vm.sh
@@ -11,10 +11,11 @@ sudo apt-get -y install \
 
 echo "-> Installing node.js"
 
-if [ ! -d node ]; then
+if [ ! -d /home/vagrant/node ]; then
   curl -O http://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}.tar.gz
   tar -zxf node-${NODE_VERSION}.tar.gz
   mv node-${NODE_VERSION} node
+  chown -R vagrant:vagrant node
   rm -rf node-${NODE_VERSION}.tar.gz
 fi
 cd node
@@ -22,11 +23,12 @@ cd node
 # Unfortunately we can't put this into our project dir as vboxfs complains
 # about hardlinks in the tar : /
 echo "-> Installing code sourcer (arm toolchain)"
-if [ ! -d ~/armtools ]; then
+if [ ! -d /home/vagrant/armtools ]; then
   cd ~
   tarball="arm-2012.03-57-arm-none-linux-gnueabi-i686-pc-linux-gnu.tar.bz2"
   curl -OL http://www.codesourcery.com/public/gnu_toolchain/arm-none-linux-gnueabi/${tarball}
   tar -xf ${tarball}
   mv arm-2012.03 armtools
+  chown -R vagrant:vagrant armtools
   rm -rf ${tarball}
 fi


### PR DESCRIPTION
- the Vagrantfile is now compatible with vagrant 1.2
- the ardrone2.sh helper script halts the VM after a build
- correct permissions for the build dependencies are set
