### PR TITLE
Make the node binary executable when installing

### DIFF
--- a/helpers/ardrone2.sh
+++ b/helpers/ardrone2.sh
@@ -19,7 +19,7 @@ if [[ $a == "Y" || $a == "y" || $a = "" ]]; then
   echo "-> Uploading binary"
   ftp -u ftp://anonymous:anonymous@192.168.1.1/node build/bin/node
   echo "-> Installing"
-  { echo "cd /data/video && mv ./node /bin && rm -rf node && exit"; sleep 1; } | telnet 192.168.1.1
+  { echo "cd /data/video && mv ./node /bin && chmod u+x /bin/node && rm -rf node && exit"; sleep 1; } | telnet 192.168.1.1
   echo "-> Installation completed!"
 else
   echo "-> Build completed!"


### PR DESCRIPTION
Just trying this out and noticed the helper script doesn't do this automatically.

:helicopter: 
